### PR TITLE
Temporary hack to load GFAs containing more than 256 paths

### DIFF
--- a/gfagraphs/gfagraphs.py
+++ b/gfagraphs/gfagraphs.py
@@ -763,8 +763,15 @@ class Graph():
                 offsets=node.datas['PO'] if 'PO' in node.datas else None,
                 sequence=node.datas.get('seq', '')
             )
-        palette: list = get_palette(
-            len(path_list := self.get_path_list()), as_hex=True)
+
+        #hack to run with more than 256 paths
+        path_list = self.get_path_list()
+        number_of_colors = len(path_list)
+        colormap = viridis = mpl.colormaps['viridis'].resampled(number_of_colors)
+        palette = [rgb2hex(colormap(int(x * colormap.N / number_of_colors))) for x in range(number_of_colors)]
+        # palette: list = get_palette(
+        #     len(path_list := self.get_path_list()), as_hex=True)
+
         self.colors = {p.datas["name"]: palette[i]
                        for i, p in enumerate(path_list)}
         if len(path_list) > 0:


### PR DESCRIPTION
@Tharos-ux : bug observed by Daria.

Using  `get_palette()` from `mathplotlib_tools.py` generates a crash when trying to load a GFA with more than 256 paths.

Indeed, this function returns a palette bounded by :

```python
number_of_colors = min(colormap.N, number_of_colors)
```

**Problem: N=256 by default** in the colormap constructor, which is instantiated before this line via an eval function. As a results, the min is always 256 and GFAs with more than 256 paths will crash the gfagraphs GFA parser.

**Temporary fix in this PR**:  a manual instanciationof a Colormap is followed by the build of the palette, reproducing a few lines from `get_palette()`.

**Long term fix?** : the GFA parser mixes concepts of parsing and visualisation. The latter should probably be separated and plotting operations should be split from file related operations. (mathplotlib should not be involved when only trying to load GFAs).